### PR TITLE
Fix pagination in Sections and sub-Sections

### DIFF
--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,44 +1,28 @@
 <div class="pager{{ if .Next }}{{ else }} pager_lean{{ end }}">
   <div class="pager_item prev">
     {{ with .NextInSection }}
-      <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-        <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-        <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-        <span class="pager_label">{{ .Title }}</span>
-      </a>
+      {{ partial "pagerlinkleft" . }}
     {{ else }}
       {{ if .IsPage}}
         {{ with .Parent }}
-          <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-            <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-            <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-            <span class="pager_label">{{ .Title }}</span>
-          </a>
+          {{ partial "pagerlinkleft" . }}
         {{ end }}
       {{ end }}
     {{ end }}
   </div>
 
+  <div class="pager_item next">
   {{ if .IsSection }}
-    {{range first 1 .Pages }}
-      <div class="pager_item next">
-        <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-          <span class="pager_label">{{ .Title }}</span>
-          <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-          <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-        </a>
-      </div>
+    {{ range first 1 .Pages }}
+      {{ partial "pagerlinkright" . }}
     {{ end }}
   {{ end }}
-
+        
   {{ with .PrevInSection }}
     <div class="pager_item next">
-      <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-        <span class="pager_label">{{ .Title }}</span>
-        <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-        <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-      </a>
+      {{ partial "pagerlinkright" . }}
+        </div>
+      {{ end }}
     </div>
-  {{ end }}
 </div>
 {{ partialCached "sprites" . }}

--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -6,6 +6,16 @@
         <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
         <span class="pager_label">{{ .Title }}</span>
       </a>
+    {{ else }}
+      {{ if .IsPage}}
+        {{ with .Parent }}
+          <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+            <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+            <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+            <span class="pager_label">{{ .Title }}</span>
+          </a>
+        {{ end }}
+      {{ end }}
     {{ end }}
   </div>
 

--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,24 +1,34 @@
 <div class="pager{{ if .Next }}{{ else }} pager_lean{{ end }}">
-  {{ with .Site.RegularPages.Next . }}
-  <div class="pager_item prev">
-    <!-- <span class="pager_meta">PREVIOUS</span> -->
-    <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-      <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-      <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-      <span class="pager_label">{{ .Title }}</span>
-    </a>
-  </div>
+  {{ with .NextInSection }}
+    <div class="pager_item prev">
+      <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+        <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+        <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+        <span class="pager_label">{{ .Title }}</span>
+      </a>
+    </div>
   {{ end }}
 
-  {{ with .Site.RegularPages.Prev . }}
-  <div class="pager_item next">
-    <!-- <span class="pager_meta">NEXT</span> -->
-    <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
-      <span class="pager_label">{{ .Title }}</span>
-      <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
-      <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
-    </a>
-  </div>
+  {{ if .IsSection }}
+    {{range first 1 .Pages }}
+      <div class="pager_item next">
+        <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+          <span class="pager_label">{{ .Title }}</span>
+          <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+          <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+        </a>
+      </div>
+    {{ end }}
+  {{ end }}
+
+  {{ with .PrevInSection }}
+    <div class="pager_item next">
+      <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+        <span class="pager_label">{{ .Title }}</span>
+        <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+        <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+      </a>
+    </div>
   {{ end }}
 </div>
 {{ partialCached "sprites" . }}

--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,13 +1,13 @@
 <div class="pager{{ if .Next }}{{ else }} pager_lean{{ end }}">
-  {{ with .NextInSection }}
-    <div class="pager_item prev">
+  <div class="pager_item prev">
+    {{ with .NextInSection }}
       <a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
         <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
         <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
         <span class="pager_label">{{ .Title }}</span>
       </a>
-    </div>
-  {{ end }}
+    {{ end }}
+  </div>
 
   {{ if .IsSection }}
     {{range first 1 .Pages }}

--- a/layouts/partials/pagerlinkleft.html
+++ b/layouts/partials/pagerlinkleft.html
@@ -1,0 +1,5 @@
+<a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+  <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+  <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+  <span class="pager_label">{{ .Title }}</span>
+</a>

--- a/layouts/partials/pagerlinkright.html
+++ b/layouts/partials/pagerlinkright.html
@@ -1,0 +1,5 @@
+<a href="{{ .Permalink }}" class="pager_link button" title="{{ .Title }}">
+  <span class="pager_label">{{ .Title }}</span>
+  <img class="pager_link_next light" src="{{ (absURL "/images/next.svg") }}">
+  <img class="pager_link_next dark" src="{{ (absURL "/images/next-dark.svg") }}">
+</a>


### PR DESCRIPTION
This PR fixes Phala-Network/phala-wiki#31

## Changes / fixes
- Uses the Hugo Sections and Page variables to determine what is the correct next page. 
- If the current URL is a Section, the `Next` button will be to the first page of that section
- If the current URL is a Page, the `Prev` and `Next` buttons will point to their sibling pages within the section.

## Screenshots (if applicable)

When the URL is a section:
<img width="1278" alt="Screen Shot 2021-04-14 at 12 09 07 PM" src="https://user-images.githubusercontent.com/6848941/114765669-48bd2d00-9d1a-11eb-8d19-007b131c3777.png">

When the URL is a page:

<img width="1271" alt="Screen Shot 2021-04-14 at 12 08 47 PM" src="https://user-images.githubusercontent.com/6848941/114765590-2deab880-9d1a-11eb-9424-96f26a5a0d8c.png">
